### PR TITLE
Ie dragfix

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -197,7 +197,7 @@ export interface RangeProps extends CommonApiProps {
     /**
      * addMode onAdd handler (will be called when item is added to slider via addMode)
      */
-    onAdd: (value: number) => any;
+    onAdd?: (value: number) => any;
 }
 
 export interface HandleProps extends CommonApiProps {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logicsoftware/slider",
-  "version": "8.6.17",
+  "version": "8.6.18",
   "description": "Slider UI component for React",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logicsoftware/slider",
-  "version": "8.6.10",
+  "version": "8.6.11",
   "description": "Slider UI component for React",
   "keywords": [
     "react",

--- a/src/Range.jsx
+++ b/src/Range.jsx
@@ -50,7 +50,7 @@ class Range extends React.Component {
       bounds,
       isHovered: false,
       addMode: true,
-      addBound: 0,
+      addBound: null,
       currentlyDragging: false,
     };
   }

--- a/src/Range.jsx
+++ b/src/Range.jsx
@@ -49,7 +49,7 @@ class Range extends React.Component {
       recent,
       bounds,
       isHovered: false,
-      addMode: true,
+      addMode: this.isAddEnabled(),
       addBound: null,
       currentlyDragging: false,
     };


### PR DESCRIPTION
[Task 35634:Пофиксить поведение в IE11 (баг в самой либе)](https://tfshost.dev.logicsoftware.net:8083/tfs/DefaultCollection/EasyProjects/_workitems/edit/35634)
Изначально баг появился из-за того, что ie11 ставит в фокус элемент вне зависимости от того, ес=ть ли на нем вообще tabIndex.
Отломали onFocus, onBlur и все touch ивенты (т.к мы не используем клавиатурную навигацию и тач устройства) +  У них в библиотеке в компоненте Range есть баг при котором если сфокусит один из драгов + keybord arrow = [UI crash](https://github.com/react-component/slider/issues/519).